### PR TITLE
In hu_read_html(), fix wc$getPage input: test_url --> url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Version: 0.1.0
 Date: 2018-12-16
 Authors@R: c(
     person("Bob", "Rudis", email = "bob@rud.is", role = c("aut", "cre"), 
-           comment = c(ORCID = "0000-0001-5670-2640"))
+           comment = c(ORCID = "0000-0001-5670-2640")),
+    person("Everet", "Rummel", email = "everet.rummel@gmail.com", role = "ctb")
   )
 Maintainer: Bob Rudis <bob@rud.is>
 Description: 'HtmlUnit' (<http://htmlunit.sourceforge.net/>) is a "'GUI'-Less 

--- a/R/hu-read-html.R
+++ b/R/hu-read-html.R
@@ -80,7 +80,7 @@ hu_read_html <- function(url,
   if (enable_dnt) wc_opts$setDoNotTrackEnabled(TRUE)
   if (download_images) wc_opts$setDownloadImages(TRUE)
 
-  pg <- wc$getPage(test_url)
+  pg <- wc$getPage(url)
 
   # response <- pg$getWebResponse()
   # content <- response$getContentAsString()


### PR DESCRIPTION
Line 83 of `hu_read_html()` used to take `test_url` as input. I think this was meant to take `url` as input.

After installing `htmlunit` and `htmlunitjars`, whenever I call `hu_read_html()` with any input other than a `test_url` object, it throws the following:

>Error in wc$getPage(test_url) : object 'test_url' not found

E.g.,
```
library(htmlunit)
home_url = 'https://hrbrmstr.github.io/htmlunitjars/index.htm'
pg = pg <- hu_read_html(home_url)
```